### PR TITLE
fix: correct UnicodeEncodeError in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ pip install git+https://github.com/NBChub/bgcflow_wrapper.git
 ```
 
 ### Setup via Python venv
-Alternative, using python virtual environment:
-````bash
+Alternative way to setup using python virtual environment:
+```bash
 # create and activate python virtual environment
 python -m venv env
 source env/bin/activate

--- a/README.md
+++ b/README.md
@@ -25,11 +25,23 @@ For more details, see [documentation](https://NBChub.github.io/bgcflow_wrapper/)
 
 ## Setup
 --------
-To install bgcflow_wrapper, run this command in your
+### Setup via Conda
+To install `bgcflow_wrapper` with conda, run this command in your
 terminal:
 
 ```bash
-# create a new virtual environment
+# create and activate new conda environment
+conda create -n bgcflow pip -y
+conda activate bgcflow
+
+# install BGCFlow wrapper
+pip install git+https://github.com/NBChub/bgcflow_wrapper.git
+```
+
+### Setup via Python venv
+Alternative, using python virtual environment:
+````bash
+# create and activate python virtual environment
 python -m venv env
 source env/bin/activate
 

--- a/src/bgcflow/mkdocs.py
+++ b/src/bgcflow/mkdocs.py
@@ -100,7 +100,7 @@ def generate_mkdocs_report(
         "rule_table": df_results.to_markdown(index=False),
     }
     j2_template = Template(index_template)
-    with open(docs_dir / "index.md", "w") as f:
+    with open(docs_dir / "index.md", "w", encoding='utf-8') as f:
         f.write(j2_template.render(data))
 
     # generate main.py macros


### PR DESCRIPTION
This PR fix `UnicodeEncodeError: 'charmap' codec can't encode character '\u0142' in position 2792: character maps to <undefined>` when running `bgcflow serve` on Windows